### PR TITLE
fix: snapcraft pack lint warnings

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,3 +58,5 @@ parts:
       wget https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-releases/refs/tags/v0.130.0/distributions/otelcol-ebpf-profiler/manifest.yaml -O ${CRAFT_PART_BUILD}/manifest.yaml
       builder --config="${CRAFT_PART_BUILD}/manifest.yaml"
       install -D -m755 ${CRAFT_PART_BUILD}/_build/otelcol-ebpf-profiler ${CRAFT_PART_INSTALL}/bin/otel-ebpf-profiler
+    build-attributes:
+      - enable-patchelf


### PR DESCRIPTION
## Issue
When packing the snap, we get 
<img width="2753" height="269" alt="image (15)" src="https://github.com/user-attachments/assets/5ae7a6d0-213b-4b3d-8277-63d8f0b044be" />

## Solution
Auto patch ELF files as described here 
https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-classic-linter/#enable-automatic-elf-file-patching